### PR TITLE
include Libraries as submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "KiCAD-libs"]
+	path = KiCAD-libs
+	url = https://github.com/Jan--Henrik/KiCAD-libs

--- a/fp-lib-table
+++ b/fp-lib-table
@@ -1,0 +1,3 @@
+(fp_lib_table
+  (lib (name "otter")(type "KiCad")(uri "${KIPRJMOD}/KiCAD-libs/otter.pretty")(options "")(descr ""))
+)

--- a/sym-lib-table
+++ b/sym-lib-table
@@ -1,0 +1,3 @@
+(sym_lib_table
+  (lib (name "otter")(type "Legacy")(uri "${KIPRJMOD}/KiCAD-libs/otter.lib")(options "")(descr ""))
+)


### PR DESCRIPTION
* Include libraries as submodules, so that you get the state-at-project-creation version when you do a `git clone --recursive https://github.com/Jan--Henrik/USB-LED-Otter`
* Add symbol and footprint tables to enable usage of that